### PR TITLE
Settings page feature 

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
   def index
+    @name = session[:name]
   end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,10 @@
+class SettingsController < ApplicationController
+  def index
+    @name = session[:name]
+  end
+
+  def update
+    session[:name] = params[:name]
+    redirect_to root_path, notice: "Settings updated."
+  end
+end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,2 @@
+module SettingsHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,8 @@
 <div class="max-w-3xl mx-auto p-6 text-center">
-  <h1 class="text-4xl font-bold text-gray-800 mb-8">Welcome</h1>
+  <h1 class="text-4xl font-bold text-gray-800 mb-8">Welcome <%= @name.present? ? ", #{@name}" : "" %>!</h1>
+<% unless @name.present? %>
+  <p>Go to <%= link_to content_tag(:strong, "Settings"), settings_path %> and set your name 😊</p>
+<% end %>
   <p class="text-lg text-gray-600 mb-10">Choose where you'd like to start</p>
 
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
@@ -10,6 +13,12 @@
         <p class="text-gray-600 mt-2">Start your day with a mood check-in</p>
       </div>
     <% end %>
+
+</div>
+
+
+
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
 
     <%= link_to affirmations_path, class: "block group" do %>
       <div class="border border-gray-200 rounded-2xl p-8 hover:shadow-lg transition bg-white">

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,0 +1,15 @@
+
+<div class="max-w-lg mx-auto mt-12 bg-white rounded-xl shadow-md p-8">
+  <h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">Settings</h1>
+
+  <%= form_with url: settings_path, method: :post, local: true do |form| %>
+    <div class="mb-6">
+      <%= form.label :name, "Your name:", class: "block text-lg font-medium text-gray-700 mb-2" %>
+      <%= form.text_field :name, value: @name, placeholder: "Enter your name", class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
+
+    <div class="flex justify-center">
+      <%= form.submit "Save", class: "bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-6 rounded-lg transition duration-200" %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "settings/index"
+  get "settings/update"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -24,4 +26,6 @@ Rails.application.routes.draw do
   post "gratitude" => "gratitude#store", as: :store_gratitude
   get "affirmations/random" => "affirmations#random", as: :random_affirmation
   get "affirmations/ai" => "affirmations#ai", as: :ai_affirmation
+  get  "settings", to: "settings#index"
+  post "settings", to: "settings#update"
 end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class SettingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get settings page" do
+    get settings_url
+    assert_response :success
+    assert_select "h1", "Settings"
+  end
+
+  test "should save name in session and redirect" do
+    post settings_url, params: { name: "Lucas" }
+    assert_equal "Lucas", @request.session[:name]
+    assert_redirected_to root_url
+    follow_redirect!
+  assert_select "h1", "Welcome , Lucas!"
+  end
+end


### PR DESCRIPTION
Feature: User Settings Page
This PR adds a Settings page (/settings) where users can set their name, which is then displayed on the home page.

Key changes:

Created a Settings page with a form to set the user’s name (stored in session, not in the database).
The name is shown on the home page if set; otherwise, the user is prompted to go to Settings and set their name.
All interface and tests are now in English.
Added both RSpec and Minitest tests for the new feature.
Improved the Settings page styling with Tailwind CSS.
Note:
Persistence in the database can be added in a future update.
<img width="886" height="376" alt="Screenshot from 2025-10-05 18-47-46" src="https://github.com/user-attachments/assets/ab54fcb1-f589-4a6b-aa7d-f7d30f2dede4" />
<img width="1525" height="584" alt="Screenshot from 2025-10-05 18-45-57" src="https://github.com/user-attachments/assets/b627c19a-51ec-4051-b49e-72c0324fc9e4" />
<img width="1525" height="584" alt="Screenshot from 2025-10-05 18-45-50" src="https://github.com/user-attachments/assets/72d493b4-1946-48aa-8a37-a1c899218b91" />
<img width="1525" height="584" alt="Screenshot from 2025-10-05 18-45-15" src="https://github.com/user-attachments/assets/a2e48c26-5815-4156-848e-d345169238df" />
