### PR TITLE
Make conversation sidebar collapsible on mobile

### DIFF
--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -1,0 +1,63 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Off-canvas conversation sidebar.
+//
+// Below the `md` breakpoint the sidebar is hidden off-screen so the chat gets
+// the full viewport width (see issue #136). A hamburger button slides it in
+// over a dimmed backdrop. At `md` and up the sidebar is always visible and this
+// controller stays out of the way.
+export default class extends Controller {
+  static targets = ["panel", "backdrop", "toggle"]
+
+  connect() {
+    // The sidebar is omitted entirely when there are no conversations yet.
+    if (!this.hasPanelTarget) return
+
+    this.closeOnDesktop = this.closeOnDesktop.bind(this)
+    this.desktopQuery = window.matchMedia("(min-width: 768px)")
+    this.desktopQuery.addEventListener("change", this.closeOnDesktop)
+    this.close()
+  }
+
+  disconnect() {
+    this.desktopQuery?.removeEventListener("change", this.closeOnDesktop)
+    document.body.classList.remove("overflow-hidden")
+  }
+
+  toggle() {
+    this.isOpen ? this.close() : this.open()
+  }
+
+  open() {
+    if (!this.hasPanelTarget) return
+
+    this.isOpen = true
+    this.panelTarget.classList.remove("-translate-x-full")
+    this.panelTarget.classList.add("translate-x-0")
+    this.backdropTarget.classList.remove("hidden")
+    this.toggleTarget.setAttribute("aria-expanded", "true")
+    document.body.classList.add("overflow-hidden")
+  }
+
+  close() {
+    if (!this.hasPanelTarget) return
+
+    this.isOpen = false
+    this.panelTarget.classList.add("-translate-x-full")
+    this.panelTarget.classList.remove("translate-x-0")
+    this.backdropTarget.classList.add("hidden")
+    this.toggleTarget.setAttribute("aria-expanded", "false")
+    document.body.classList.remove("overflow-hidden")
+  }
+
+  // Close when Escape is pressed.
+  closeOnEscape(event) {
+    if (event.key === "Escape") this.close()
+  }
+
+  // Reset state when the viewport grows past the breakpoint, so the sidebar
+  // isn't left in an "open" state with the body scroll locked.
+  closeOnDesktop(event) {
+    if (event.matches) this.close()
+  }
+}

--- a/app/views/conversations/_sidebar.html.erb
+++ b/app/views/conversations/_sidebar.html.erb
@@ -1,0 +1,55 @@
+<%#
+  Conversation list sidebar.
+
+  Off-canvas below `md` (issue #136) so the chat gets the full width on a phone;
+  statically docked at `md` and up.
+
+  Locals:
+    conversations - the list to render
+    current       - the active conversation, if any (nil on the "new" page)
+%>
+<% current = local_assigns.fetch(:current, nil) %>
+
+<!-- Backdrop (mobile only) -->
+<div data-sidebar-target="backdrop"
+     data-action="click->sidebar#close"
+     class="hidden fixed inset-0 z-30 bg-black/40 md:hidden"
+     aria-hidden="true"></div>
+
+<nav id="conversation-sidebar"
+     data-sidebar-target="panel"
+     aria-label="Conversations"
+     class="fixed inset-y-0 left-0 z-40 w-64 shrink-0 overflow-y-auto bg-white p-4 shadow-xl transition-transform duration-200 ease-in-out -translate-x-full
+            md:static md:z-auto md:w-56 md:translate-x-0 md:overflow-visible md:bg-transparent md:p-0 md:shadow-none">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-semibold text-gray-600 uppercase tracking-wide">Conversations</h2>
+    <div class="flex items-center gap-1">
+      <%= link_to "New convo", conversations_path, class: "text-xs px-2 py-1 bg-sky-600 text-white font-semibold rounded-lg hover:bg-sky-700 transition" %>
+      <button type="button"
+              data-action="sidebar#close"
+              class="md:hidden p-1 text-gray-400 hover:text-gray-700 transition"
+              aria-label="Close conversations">
+        &#x2715;
+      </button>
+    </div>
+  </div>
+
+  <ul class="space-y-1">
+    <% conversations.each do |conv| %>
+      <li class="flex items-center gap-1 group">
+        <%= link_to conversation_path(conv),
+                    data: { action: "sidebar#close" },
+                    class: "flex-1 min-w-0 px-3 py-2 rounded-lg text-sm transition #{ conv == current ? 'bg-sky-100 text-sky-800 font-semibold' : 'text-gray-700 hover:bg-gray-100' }" do %>
+          <span class="text-xs opacity-60"><%= conv.updated_at.in_time_zone.strftime("%-m/%-d %-I:%M %p") %></span>
+          <span class="block truncate"><%= conv.first_user_message %></span>
+        <% end %>
+        <%= button_to conversation_path(conv),
+                      method: :delete,
+                      form: { data: { turbo_confirm: "Delete this conversation?" } },
+                      class: "opacity-100 md:opacity-0 md:group-hover:opacity-100 shrink-0 px-1.5 py-1 text-gray-400 hover:text-red-500 transition rounded" do %>
+          &#x2715;
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -5,37 +5,34 @@
   .chat-msg.assistant { margin-right: auto; background: #f1f5f9; color: #0f172a; }
 </style>
 
-<div class="flex gap-4 max-w-5xl mx-auto p-6">
+<div class="flex gap-4 max-w-5xl mx-auto p-0 md:p-6"
+     data-controller="sidebar"
+     data-action="keydown@window->sidebar#closeOnEscape">
+
   <% if @conversations.any? %>
-    <nav id="conversation-sidebar" class="w-56 shrink-0">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="text-sm font-semibold text-gray-600 uppercase tracking-wide">Conversations</h2>
-        <%= link_to "New convo", conversations_path, class: "text-xs px-2 py-1 bg-sky-600 text-white font-semibold rounded-lg hover:bg-sky-700 transition" %>
-      </div>
-      <ul class="space-y-1">
-        <% @conversations.each do |conv| %>
-          <li class="flex items-center gap-1 group">
-            <%= link_to conversation_path(conv), class: "flex-1 min-w-0 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-gray-100 transition" do %>
-              <span class="text-xs text-gray-400"><%= conv.updated_at.in_time_zone.strftime("%-m/%-d %-I:%M %p") %></span>
-              <span class="block truncate"><%= conv.first_user_message %></span>
-            <% end %>
-            <%= button_to conversation_path(conv),
-                          method: :delete,
-                          form: { data: { turbo_confirm: "Delete this conversation?" } },
-                          class: "opacity-0 group-hover:opacity-100 shrink-0 px-1.5 py-1 text-gray-400 hover:text-red-500 transition rounded" do %>
-              &#x2715;
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </nav>
+    <%= render "conversations/sidebar", conversations: @conversations %>
   <% end %>
 
   <div class="flex-1 min-w-0">
     <%= form_with url: conversations_path,
                   data: { controller: "conversation", action: "submit->conversation#disableSend turbo:submit-end->conversation#enableSend" } do |f| %>
-      <div class="flex items-center gap-4 mb-4">
-        <h1 class="text-2xl font-bold text-gray-800">Wellness Coach Chat</h1>
+      <div class="flex items-center gap-3 mb-4">
+        <% if @conversations.any? %>
+          <button type="button"
+                  data-sidebar-target="toggle"
+                  data-action="sidebar#toggle"
+                  class="md:hidden shrink-0 p-2 -ml-1 rounded-lg text-gray-600 hover:bg-gray-100 transition"
+                  aria-controls="conversation-sidebar"
+                  aria-expanded="false"
+                  aria-label="Show conversations">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        <% end %>
+
+        <h1 class="text-xl md:text-2xl font-bold text-gray-800">Wellness Coach Chat</h1>
+
         <div class="flex items-center gap-2">
           <%= f.check_box :use_positive_psychology,
                           class: "w-4 h-4 accent-sky-600 cursor-pointer" %>
@@ -44,7 +41,7 @@
         </div>
       </div>
 
-      <div class="bg-white rounded-xl shadow flex flex-col" style="height: 520px;">
+      <div class="bg-white rounded-xl shadow flex flex-col h-[65vh] md:h-[520px]">
         <div class="flex-1 overflow-auto px-4 py-4">
           <div class="chat-msg assistant">
             <p><%= Conversations::SendMessageService::INTRO_MESSAGE %></p>
@@ -57,10 +54,10 @@
                              placeholder: "What's on your mind?",
                              autocomplete: "off",
                              data: { conversation_target: "input" },
-                             class: "flex-1 px-3 py-2 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-sky-300" %>
+                             class: "flex-1 min-w-0 px-3 py-2 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-sky-300" %>
             <%= f.submit "Send",
                          data: { conversation_target: "sendBtn" },
-                         class: "px-4 py-2 bg-sky-600 text-white rounded-lg font-semibold hover:bg-sky-700 transition" %>
+                         class: "shrink-0 px-4 py-2 bg-sky-600 text-white rounded-lg font-semibold hover:bg-sky-700 transition" %>
           </div>
         </div>
       </div>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -5,34 +5,28 @@
   .chat-msg.assistant { margin-right: auto; background: #f1f5f9; color: #0f172a; }
 </style>
 
-<div class="flex gap-4 max-w-5xl mx-auto p-6">
-  <nav id="conversation-sidebar" class="w-56 shrink-0">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-gray-600 uppercase tracking-wide">Conversations</h2>
-      <%= link_to "New convo", conversations_path, class: "text-xs px-2 py-1 bg-sky-600 text-white font-semibold rounded-lg hover:bg-sky-700 transition" %>
-    </div>
-    <ul class="space-y-1">
-      <% @conversations.each do |conv| %>
-        <li class="flex items-center gap-1 group">
-          <%= link_to conversation_path(conv),
-                      class: "flex-1 min-w-0 px-3 py-2 rounded-lg text-sm transition #{ conv == @conversation ? 'bg-sky-100 text-sky-800 font-semibold' : 'text-gray-700 hover:bg-gray-100' }" do %>
-            <span class="text-xs opacity-60"><%= conv.updated_at.in_time_zone.strftime("%-m/%-d %-I:%M %p") %></span>
-            <span class="block truncate"><%= conv.first_user_message %></span>
-          <% end %>
-          <%= button_to conversation_path(conv),
-                        method: :delete,
-                        form: { data: { turbo_confirm: "Delete this conversation?" } },
-                        class: "opacity-0 group-hover:opacity-100 shrink-0 px-1.5 py-1 text-gray-400 hover:text-red-500 transition rounded" do %>
-            &#x2715;
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </nav>
+<div class="flex gap-4 max-w-5xl mx-auto p-0 md:p-6"
+     data-controller="sidebar"
+     data-action="keydown@window->sidebar#closeOnEscape">
+
+  <%= render "conversations/sidebar", conversations: @conversations, current: @conversation %>
 
   <div class="flex-1 min-w-0">
-    <div class="flex items-center gap-4 mb-4">
-      <h1 class="text-2xl font-bold text-gray-800">Wellness Coach Chat</h1>
+    <div class="flex items-center gap-3 mb-4">
+      <button type="button"
+              data-sidebar-target="toggle"
+              data-action="sidebar#toggle"
+              class="md:hidden shrink-0 p-2 -ml-1 rounded-lg text-gray-600 hover:bg-gray-100 transition"
+              aria-controls="conversation-sidebar"
+              aria-expanded="false"
+              aria-label="Show conversations">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+
+      <h1 class="text-xl md:text-2xl font-bold text-gray-800">Wellness Coach Chat</h1>
+
       <%= form_with model: @conversation, method: :patch, class: "flex items-center gap-2" do |f| %>
         <%= f.check_box :use_positive_psychology,
                         disabled: @conversation.use_positive_psychology,
@@ -43,7 +37,7 @@
       <% end %>
     </div>
 
-    <div class="bg-white rounded-xl shadow flex flex-col" style="height: 520px;">
+    <div class="bg-white rounded-xl shadow flex flex-col h-[65vh] md:h-[520px]">
       <div id="messages" class="flex-1 overflow-auto px-4 py-4">
         <%= render partial: "conversations/message", collection: @messages, as: :message %>
       </div>
@@ -56,10 +50,10 @@
                            placeholder: "Type a message…",
                            autocomplete: "off",
                            data: { conversation_target: "input" },
-                           class: "flex-1 px-3 py-2 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-sky-300" %>
+                           class: "flex-1 min-w-0 px-3 py-2 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-sky-300" %>
           <%= f.submit "Send",
                        data: { conversation_target: "sendBtn" },
-                       class: "px-4 py-2 bg-sky-600 text-white rounded-lg font-semibold hover:bg-sky-700 transition" %>
+                       class: "shrink-0 px-4 py-2 bg-sky-600 text-white rounded-lg font-semibold hover:bg-sky-700 transition" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Below the md breakpoint the conversation list is now off-canvas: a
hamburger button slides it in over a dimmed backdrop, so the chat gets
the full phone viewport. At md and up nothing changes - the sidebar
stays docked as before.

- Add sidebar_controller.js (open/close, Escape, backdrop, body scroll
  lock, auto-close when the viewport grows past md)
- Extract the duplicated nav in conversations/index and show into a
  shared _sidebar partial
- Chat panel height is now 65vh on mobile instead of a fixed 520px
- Delete buttons are always visible on touch (no hover on phones)

Closes #136
